### PR TITLE
ENH: Replace pybind11 with the python + numpy C-api

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -13,9 +13,12 @@ defaults:
   run:
     shell: bash
 
+env:
+  CP2K_VERSION: "9.1"
+
 jobs:
   build_wheels:
-    name: Build wheels ${{ matrix.version }}-${{ matrix.buildplat[1] }}
+    name: Build wheels ${{ matrix.buildplat[1] }}
     runs-on: ${{ matrix.buildplat[0] }}
     strategy:
       fail-fast: false
@@ -24,11 +27,6 @@ jobs:
         - [ubuntu-20.04, manylinux_x86_64]
         - [ubuntu-20.04, manylinux_aarch64]
         - [macos-10.15, macosx_x86_64]
-        version:
-        - "cp37"
-        - "cp38"
-        - "cp39"
-        - "cp310"
 
     steps:
       - uses: actions/checkout@v3
@@ -52,16 +50,16 @@ jobs:
           cp -r output/share/* /usr/local/share/
 
       - name: Build wheels (x86_64)
-        uses: pypa/cibuildwheel@v2.4.0
+        uses: pypa/cibuildwheel@v2.5.0
         if: matrix.buildplat[1] != 'manylinux_aarch64'
         env:
-          CIBW_BUILD: ${{ matrix.version }}-${{ matrix.buildplat[1] }}
+          CIBW_BUILD: cp37-${{ matrix.buildplat[1] }}
 
       - name: Build wheels (aarch64)
         uses: pypa/cibuildwheel@v2.4.0
         if: matrix.buildplat[1] == 'manylinux_aarch64'
         env:
-          CIBW_BUILD: ${{ matrix.version }}-${{ matrix.buildplat[1] }}
+          CIBW_BUILD: cp37-${{ matrix.buildplat[1] }}
           CIBW_ARCHS_LINUX: aarch64
 
       - uses: actions/upload-artifact@v3
@@ -69,8 +67,133 @@ jobs:
           name: wheels
           path: ./wheelhouse/*.whl
 
+  test_wheels_x86_64:
+    name: Test wheels ${{ matrix.version[0] }}-${{ matrix.buildplat[1] }}
+    runs-on: ${{ matrix.buildplat[0] }}
+    needs: [build_wheels]
+    strategy:
+      fail-fast: false
+      matrix:
+        buildplat:
+        - [ubuntu-latest, manylinux_x86_64, manylinux2014_x86_64]
+        - [macos-latest, macosx_x86_64, macosx_10_14_x86_64]
+        version:
+        - ["cp37", "3.7"]
+        - ["cp38", "3.8"]
+        - ["cp39", "3.9"]
+        - ["cp310", "3.10"]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.version[1] }}
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheels
+          path: dist
+
+      - name: Install dependencies
+        run: |
+          WHL_NAME=$(python scripts/get_whl_name.py dist ${{ matrix.buildplat[2] }})
+          pip install "$WHL_NAME"[test]
+
+      - name: Python info
+        run: |
+          which python
+          python --version
+
+      - name: Installed packages
+        run: pip list
+
+      - name: Test with pytest
+        run: |
+          # TODO: Install CP2K on macos once a workaround is found for SCM-NV/qmflows#295
+          case "${{ matrix.buildplat[0] }}" in
+            "ubuntu-latest")
+              bash scripts/download_cp2k.sh x86_64 $CP2K_VERSION ;;
+          esac
+
+          mkdir /tmp/nanoqm
+          cp setup.cfg /tmp/nanoqm/
+          cp conftest.py /tmp/nanoqm/conftest.py
+          cp -r test /tmp/nanoqm/test
+          cd /tmp/nanoqm
+
+          pytest -m "not (slow or long)"
+
+  test_wheels_aarch64:
+    name: Test wheels ${{ matrix.version[0] }}-${{ matrix.buildplat[1] }}
+    runs-on: ${{ matrix.buildplat[0] }}
+    needs: [build_wheels]
+    strategy:
+      fail-fast: false
+      matrix:
+        buildplat:
+        - [ubuntu-latest, manylinux_aarch64]
+        version:
+        - ["cp37", "python3.7"]
+        - ["cp38", "python3.8"]
+        - ["cp39", "python3.9"]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheels
+          path: dist
+
+      - uses: uraimo/run-on-arch-action@v2
+        name: Test with pytest
+        with:
+          arch: aarch64
+          distro: ubuntu_latest
+          dockerRunArgs: |
+            --volume "${{github.workspace}}:/workspace"
+            --env CP2K_VERSION=${CP2K_VERSION}
+          install: |
+            echo "::group::Install Python"
+            apt update
+            apt install -y software-properties-common
+            add-apt-repository ppa:deadsnakes/ppa
+            apt install -y ${{ matrix.version[1] }}-full
+            ln -sf /usr/bin/${{ matrix.version[1] }} /usr/bin/python
+            ln -sf /usr/bin/${{ matrix.version[1] }} /usr/bin/python3
+            export PYTHONPATH=/usr/bin/${{ matrix.version[1] }}
+
+            echo "::group::Install pip"
+            apt install -y python3-pip
+
+            echo "::group::Install curl"
+            apt install -y curl
+          run: |
+            cd /workspace
+
+            echo "::group::Install CP2K"
+            bash scripts/download_cp2k.sh arm64 $CP2K_VERSION
+
+            echo "::group::Install the package"
+            WHL_NAME=$(python scripts/get_whl_name.py dist manylinux2014_aarch64)
+            pip install $WHL_NAME[test] --prefer-binary
+
+            echo "::group::Python info"
+            python --version
+            pip list
+
+            echo "::group::Run tests"
+            mkdir /tmp/nanoqm
+            cp setup.cfg /tmp/nanoqm/
+            cp conftest.py /tmp/nanoqm/
+            cp -r test /tmp/nanoqm/
+            cd /tmp/nanoqm
+            pytest -m "not (slow or long)"
+
   build_sdist:
-    name: Build wheels sdist
+    name: Build sdist
     runs-on: ubuntu-latest
     env:
       QMFLOWS_INCLUDEDIR: ""
@@ -103,14 +226,14 @@ jobs:
           path: ./dist/*.tar.gz
 
   test_sdist:
-    name: Test wheels sdist
+    name: Test sdist
     runs-on: ubuntu-latest
     needs: [build_sdist]
     steps:
     - uses: actions/checkout@v3
 
     - name: Install CP2K
-      run: bash scripts/download_cp2k.sh x86_64 9.1
+      run: bash scripts/download_cp2k.sh x86_64 $CP2K_VERSION
 
     - name: Info CP2K
       run: cp2k.popt --version
@@ -128,9 +251,8 @@ jobs:
     - name: Install dependencies
       run: |
         conda install -c conda-forge boost eigen libint==2.6.0 highfive
-        cd dist
-        pip install *.tar.gz -v
-        pip install -r ../test_requirements.txt
+        TGZ_NAME=$(python scripts/get_whl_name.py dist 'tar\.gz')
+        pip install $TGZ_NAME[test]
 
     - name: Conda info
       run: conda info
@@ -145,12 +267,13 @@ jobs:
         cp conftest.py /tmp/nanoqm/conftest.py
         cp -r test /tmp/nanoqm/test
         cd /tmp/nanoqm
+
         pytest -m "not (slow or long)"
 
   upload_wheels:
-    name: Upload wheels
+    name: Upload wheels & sdist
     runs-on: ubuntu-latest
-    needs: [test_sdist, build_wheels]
+    needs: [test_sdist, test_wheels_x86_64, test_wheels_aarch64]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -82,7 +82,7 @@ jobs:
         uses: actions/setup-python@v3
 
       - name: Install dependencies
-        run: pip install Cython "setuptools>=48.0" wheel "pybind11>=2.2.4"
+        run: pip install wheel setuptools numpy
 
       - name: Python info
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+/tmp
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/docs/theory.rst
+++ b/docs/theory.rst
@@ -20,7 +20,7 @@ eigenstates :math:`\phi_{i}(\mathbf{R}(t))`,
 The time-dependent coefficients are propagated according to
 
 .. math::
-   
+
    \frac{dc_j(t)}{dt} = -i\hbar^2 c_j(t) E_j(t) - \sum^{N}_{i=1}c_i(t)\sigma_{ji}(t) \quad \mathbf(2)
 
 where :math:`E_j(t)` is the energy of the jth adiabatic state and :math:`\sigma_{ji}(t)` the nonadiabatic matrix, which elements are given by the expression
@@ -52,7 +52,7 @@ Where :math:C_{\mu i} are the Molecular orbital coefficients and :math:`\mathbf{
 Nonadiabatic coupling algorithm implementation
 ----------------------------------------------
 
-The  figure belows shows schematically the workflow for calculating the Nonadiabatic 
+The  figure belows shows schematically the workflow for calculating the Nonadiabatic
 coupling matrices from a molecular dynamic trajectory. The uppermost node represent
 a molecular dynamics
 trajectory that is subsequently divided in its components andfor each geometry the molecular
@@ -73,7 +73,6 @@ Also, all the heavy numerical processing is carried out by the highly optimized 
 .. _libint2: https://github.com/evaleev/libint/wiki
 .. _HDF5: http://www.h5py.org/
 .. _PYXAID: https://www.acsu.buffalo.edu/~alexeyak/pyxaid/overview.html
-.. _Cython: http://cython.org
 .. _multiprocessing: https://docs.python.org/3.6/library/multiprocessing.html
 .. _NumPy: http://www.numpy.org
 .. _noodles: http://nlesc.github.io/noodles/

--- a/install_requirements.txt
+++ b/install_requirements.txt
@@ -2,7 +2,7 @@ h5py
 mendeleev
 more-itertools
 noodles>=0.3.3
-numpy
+numpy>=1.17.1
 scipy
 schema
 pyyaml>=5.1

--- a/libint/include/namd.hpp
+++ b/libint/include/namd.hpp
@@ -3,7 +3,7 @@
  * kind of integrals used for non-adiabatic molecular dynamics,
  * including the overlaps integrals between different geometries
  * And the dipoles and quadrupoles to compute absorption spectra.
- * This module is based on libint, Eigen and pybind11.
+ * This module is based on libint and Eigen.
  * Copyright (C) 2018-2022 the Netherlands eScience Center.
  */
 
@@ -22,9 +22,6 @@
 
 // integrals library
 #include <libint2.hpp>
-
-#include <pybind11/eigen.h>
-#include <pybind11/pybind11.h>
 
 // Eigen matrix algebra library
 #include <Eigen/Dense>

--- a/nanoqm/compute_integrals.pyi
+++ b/nanoqm/compute_integrals.pyi
@@ -9,8 +9,8 @@ def compute_integrals_couplings(
 ) -> npt.NDArray[np.float64]: ...
 
 def compute_integrals_multipole(
-    __path_xyz_1: str,
-    __path_xyz_2: str,
+    __path_xyz: str,
+    __path_hdf5: str,
     __basis_name: str,
     __multipole: str,
 ) -> npt.NDArray[np.float64]: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ requires = [
     'wheel',
 
     # Older numpy versions aren't fully compatible with Python's limited API
-    'numpy==1.17.1; python_version<"3.8" and platform_machine!="aarch64"',
-    'oldest-supported-numpy; python_version>="3.8" or platform_machine=="aarch64"',
+    'numpy==1.17.1; python_version=="3.7" and (platform_machine!="arm64" or platform_system!="Darwin") and platform_machine!="aarch64" and platform_machine!="loongarch64" and platform_system!="AIX" and platform_python_implementation != "PyPy"',
+    'oldest-supported-numpy; python_version!="3.7" or (platform_machine=="arm64" and platform_system=="Darwin") or platform_machine=="aarch64" or platform_machine=="loongarch64" or platform_system=="AIX" or platform_python_implementation == "PyPy"',
 ]
 
 [tool.mypy]
@@ -26,33 +26,18 @@ ignore_missing_imports = true
 
 [tool.cibuildwheel]
 build = [
-    "cp*-manylinux_aarch64",
-    "cp*-manylinux_x86_64",
-    "cp*-macosx_x86_64",
+    "cp37-manylinux_x86_64",
+    "cp37-manylinux-aarch64",
+    "cp37-macosx_x86_64",
 ]
 build-verbosity = "3"
 before-all = "cp licenses/LICENSE*.txt ."
-test-command = [
-    "mkdir /tmp/nanoqm",
-    "cp {project}/setup.cfg /tmp/nanoqm/",
-    "cp {project}/conftest.py /tmp/nanoqm/conftest.py",
-    "cp -r {project}/test /tmp/nanoqm/test",
-    "cd /tmp/nanoqm",
-    "pytest -m 'not (slow or long)' test",
-]
-test-extras = ["test"]
 
 [tool.cibuildwheel.linux]
 environment = { QMFLOWS_INCLUDEDIR="", QMFLOWS_LIBDIR="", CFLAGS="-Werror", LDFLAGS="-Wl,--strip-debug" }
 manylinux-x86_64-image = "ghcr.io/nlesc-nano/manylinux2014_x86_64-qmflows"
 manylinux-aarch64-image = "ghcr.io/nlesc-nano/manylinux2014_aarch64-qmflows"
 repair-wheel-command = "auditwheel -v repair -w {dest_dir} {wheel}"
-before-test = "bash {project}/scripts/download_cp2k.sh x86_64 9.1"
-test-skip = "cp310-manylinux_aarch64"  # TODO: Remove once aarch64 python 3.10 wheels are available for h5py
-
-[[tool.cibuildwheel.overrides]]
-select = "*-manylinux_aarch64"
-before-test = "bash {project}/scripts/download_cp2k.sh arm64 9.1"
 
 [tool.cibuildwheel.macos]
 # TODO: Install CP2K for the tests once a workaround can be found for SCM-NV/qmflows#295

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,14 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ['Cython', 'setuptools>=48.0', 'wheel', 'pybind11>=2.2.4']
+requires = [
+    'Cython',
+    'setuptools>=48.0',
+    'wheel',
+
+    # Older numpy versions aren't fully compatible with Python's limited API
+    'numpy==1.17.1; python_version<"3.8" and platform_machine!="aarch64"',
+    'oldest-supported-numpy; python_version>="3.8" or platform_machine=="aarch64"',
+]
 
 [tool.mypy]
 plugins = "numpy.typing.mypy_plugin"
@@ -14,7 +22,6 @@ module = [
     "noodles.*",
     "schema.*",
     "mendeleev.*",
-    "pybind11.*",
     "Cython.*",
 ]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = [
-    'Cython',
     'setuptools>=48.0',
     'wheel',
 
@@ -22,7 +21,6 @@ module = [
     "noodles.*",
     "schema.*",
     "mendeleev.*",
-    "Cython.*",
 ]
 ignore_missing_imports = true
 

--- a/scripts/get_whl_name.py
+++ b/scripts/get_whl_name.py
@@ -1,0 +1,30 @@
+"""Find the first file in the passed directory matching a given regex pattern."""
+
+from __future__ import annotations
+
+import os
+import re
+import argparse
+
+
+def main(directory: str | os.PathLike[str], pattern: str | re.Pattern[str]) -> str:
+    pattern = re.compile(pattern)
+    for i in os.listdir(directory):
+        if pattern.search(i) is not None:
+            return os.path.join(directory, i)
+    else:
+        raise FileNotFoundError(
+            f"Failed to identify a file in {os.fspath(directory)!r} "
+            f"with the following pattern: {pattern!r}"
+        )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        usage="python get_whl_name.py . manylinux2014_x86_64", description=__doc__
+    )
+    parser.add_argument("directory", help="The to-be searched directory")
+    parser.add_argument("pattern", help="The to-be searched regex pattern")
+
+    args = parser.parse_args()
+    print(main(args.directory, args.pattern))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from os.path import join
 from typing import TYPE_CHECKING
 
 import setuptools
-import pybind11
+import numpy as np
 from Cython.Distutils import build_ext
 from setuptools import Extension, find_packages, setup
 
@@ -153,13 +153,13 @@ def get_paths() -> "tuple[list[str], list[str]]":
 
 
 include_list, lib_list = get_paths()
-ext_pybind = Extension(
+libint_ext = Extension(
     'nanoqm.compute_integrals',
     sources=['libint/compute_integrals.cc'],
     include_dirs=[
         "libint/include",
         *include_list,
-        pybind11.get_include(),
+        np.get_include(),
     ],
     libraries=['hdf5', 'int2'],
     library_dirs=lib_list,
@@ -201,7 +201,7 @@ setup(
     install_requires=parse_requirements("install_requirements.txt"),
     cmdclass={'build_ext': BuildExt},
     python_requires='>=3.7',
-    ext_modules=[ext_pybind],
+    ext_modules=[libint_ext],
     extras_require={
         'test': parse_requirements("test_requirements.txt"),
         'doc': parse_requirements("doc_requirements.txt"),

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING
 
 import setuptools
 import numpy as np
-from Cython.Distutils import build_ext
 from setuptools import Extension, find_packages, setup
+from setuptools.command.build_ext import build_ext
 
 if TYPE_CHECKING:
     from distutils.ccompiler import CCompiler
@@ -91,7 +91,7 @@ class BuildExt(build_ext):
         for ext in self.extensions:
             ext.extra_compile_args = opts
             ext.extra_link_args = link_opts
-        build_ext.build_extensions(self)
+        super().build_extensions()
 
 
 def parse_requirements(path: "str | os.PathLike[str]") -> "list[str]":


### PR DESCRIPTION
By limiting ourselves to the use of the Python stable ABI, it should now be possible to create version-independent Nano-QMFlows wheels.